### PR TITLE
Fix Telegram start_param redirects for docs root and localized roots

### DIFF
--- a/book_src/overrides/main.html
+++ b/book_src/overrides/main.html
@@ -45,7 +45,40 @@
       // Handle navigation based on start_param
       const initData = webapp.initDataUnsafe;
       
-      if (window.location.pathname === "/aiogram-3-guide/" && Object.hasOwn(initData, 'auth_date')) {
+      const knownLocales = new Set(['en', 'uk', 'zh']);
+      const normalizePath = (path) => {
+        if (!path) return '/';
+        const withLeadingSlash = path.startsWith('/') ? path : `/${path}`;
+        return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`;
+      };
+      const pathFromUrl = (urlValue) => {
+        try {
+          return new URL(urlValue, window.location.origin).pathname;
+        } catch {
+          return '';
+        }
+      };
+      const siteBasePath = normalizePath(pathFromUrl('{{ config.site_url | default("", true) }}'));
+      const canonicalPath = normalizePath(pathFromUrl('{{ page.canonical_url | default("", true) }}'));
+
+      const currentPath = normalizePath(window.location.pathname);
+      const relativeToBase = currentPath.startsWith(siteBasePath)
+        ? currentPath.slice(siteBasePath.length)
+        : currentPath.slice(1);
+      const relativeSegments = relativeToBase.split('/').filter(Boolean);
+
+      const isDocsRoot = relativeSegments.length === 0
+        || (relativeSegments.length === 1 && knownLocales.has(relativeSegments[0]));
+
+      // Keep locale root (/en/, /uk/, /zh/) when redirecting from Telegram start_param
+      const localePrefix = relativeSegments.length === 1 && knownLocales.has(relativeSegments[0])
+        ? `${relativeSegments[0]}/`
+        : '';
+      const redirectRoot = canonicalPath === currentPath
+        ? currentPath
+        : `${siteBasePath}${localePrefix}`;
+
+      if (isDocsRoot && Object.hasOwn(initData, 'auth_date')) {
         if (initData.start_param) {
           // Map of start parameters to their corresponding paths
           const routeMap = {
@@ -82,10 +115,16 @@
             'chat-member': 'special-updates/#chat-member'
           };
           
-          const path = routeMap[initData.start_param] || '/';
-          const targetUrl = `${window.location.origin}${window.location.pathname}${path}`;
-          
-          window.location.href = targetUrl;
+          const path = routeMap[initData.start_param];
+
+          // Safe fallback: unknown start_param should not break or reload current page
+          if (!path) {
+            return;
+          }
+
+          const targetUrl = new URL(`${redirectRoot}${path}`, window.location.origin);
+
+          window.location.href = targetUrl.toString();
         }
       }
     });


### PR DESCRIPTION
### Motivation
- Replace a fragile hardcoded pathname check to reliably detect documentation root and localized roots. 
- Use site configuration (`config.site_url` / `page.canonical_url`) and normalized paths to compute redirect base instead of a literal string. 
- Ensure unknown `start_param` values do not break or reload the current page.

### Description
- Reworked Telegram WebApp redirect logic in `book_src/overrides/main.html` to compute `siteBasePath`, `canonicalPath` and `currentPath` with a `normalizePath` helper. 
- Detect docs root and preserve locale roots (`/en/`, `/uk/`, `/zh/`) when building redirects so Telegram `start_param` opens the same locale. 
- Keep the existing `routeMap` mapping for known `initData.start_param` values and added a safe no-op fallback for unknown parameters. 
- Construct redirect targets with `new URL(...)` to avoid string-concatenation errors and to produce a proper absolute URL.

### Testing
- Built the site with `mkdocs build -f mkdocs.yml` and the build completed successfully. 
- Verified templates render and the modified `main.html` compiles into the site without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa8d886a8832a9f37a55e031c3cad)