### PR TITLE
Localize translation notice UI strings in main override

### DIFF
--- a/book_src/overrides/main.html
+++ b/book_src/overrides/main.html
@@ -114,7 +114,7 @@
             {% include ".icons/material/translate.svg" %}
           </span>
           {{ config.extra.add_translations.translation_warning_title | default('Translation Information') }}
-          <button class="translation-notice-dismiss" type="button" aria-label="Dismiss notification">×</button>
+          <button class="translation-notice-dismiss" type="button" aria-label="{{ config.extra.add_translations.dismiss_notification_aria | default('Dismiss notification') }}">×</button>
         </p>
         <div class="translation-notification-content">
           <p class="translation-fallback-message">
@@ -167,7 +167,7 @@
                 <span class="button-text">{{ config.extra.edit_page_cta | default('Edit this page') }}</span>
               </a>
               
-              <a href="{{ repo_url }}/issues/new?title=Translation%20Issue:%20{{ page.title | urlencode }}&body=Page:%20{{ page.canonical_url | urlencode }}%0AFile:%20{{ actual_file_path | urlencode }}%0A%0ATranslation%20issue%20description:" 
+              <a href="{{ repo_url }}/issues/new?title={{ (config.extra.add_translations.issue_title_prefix | default('Translation Issue: ')) | urlencode }}{{ page.title | urlencode }}&body={{ (config.extra.add_translations.issue_body_page_label | default('Page: ')) | urlencode }}{{ page.canonical_url | urlencode }}%0A{{ (config.extra.add_translations.issue_body_file_label | default('File: ')) | urlencode }}{{ actual_file_path | urlencode }}%0A%0A{{ (config.extra.add_translations.issue_body_description_label | default('Translation issue description:')) | urlencode }}" 
                 class="md-button md-button--secondary translation-issue-btn" 
                 target="_blank" 
                 rel="noopener noreferrer">
@@ -226,7 +226,7 @@
               {% include ".icons/material/" ~ status.icon ~ ".svg" %}
             </span>
             {{ status.title }}
-            <button class="translation-notice-dismiss" type="button" aria-label="Dismiss notification">×</button>
+            <button class="translation-notice-dismiss" type="button" aria-label="{{ config.extra.add_translations.dismiss_notification_aria | default('Dismiss notification') }}">×</button>
           </p>
           <p class="status-message">{{ status.message }}</p>
           

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,11 @@ extra:
     fallback_message: 'Полный перевод временно недоступен. Приносим извинения за неудобства.'
     show_full_btn: 'Показать полный текст'
     hide_btn: 'Свернуть'
+    dismiss_notification_aria: 'Скрыть уведомление'
+    issue_title_prefix: 'Проблема перевода: '
+    issue_body_page_label: 'Страница: '
+    issue_body_file_label: 'Файл: '
+    issue_body_description_label: 'Описание проблемы перевода:'
     
   # Translation help messages (Russian)
   help_improve_title: 'Помочь с переводом'
@@ -295,6 +300,11 @@ plugins:
               fallback_message: 'Full translation is temporarily unavailable. We apologize for the inconvenience.'
               show_full_btn: 'Show full text'
               hide_btn: 'Collapse'
+              dismiss_notification_aria: 'Dismiss notification'
+              issue_title_prefix: 'Translation Issue: '
+              issue_body_page_label: 'Page: '
+              issue_body_file_label: 'File: '
+              issue_body_description_label: 'Translation issue description:'
               
             # Translation help messages (English)
             help_improve_title: 'Help with Translation'
@@ -385,6 +395,11 @@ plugins:
               fallback_message: 'Повний переклад тимчасово недоступний. Просимо вибачення за незручності.'
               show_full_btn: 'Показати повний текст'
               hide_btn: 'Згорнути'
+              dismiss_notification_aria: 'Закрити сповіщення'
+              issue_title_prefix: 'Проблема перекладу: '
+              issue_body_page_label: 'Сторінка: '
+              issue_body_file_label: 'Файл: '
+              issue_body_description_label: 'Опис проблеми перекладу:'
               
             # Translation help messages (Ukrainian)
             help_improve_title: 'Допомогти з перекладом'
@@ -471,6 +486,11 @@ plugins:
               fallback_message: '完整翻译暂时不可用，给您带来不便敬请谅解。'
               show_full_btn: '显示完整内容'
               hide_btn: '收起'
+              dismiss_notification_aria: '关闭通知'
+              issue_title_prefix: '翻译问题：'
+              issue_body_page_label: '页面：'
+              issue_body_file_label: '文件：'
+              issue_body_description_label: '翻译问题描述：'
 
             help_improve_title: '帮助改进翻译'
             help_improve_description: '这是一个开源项目，我们欢迎社区贡献。'


### PR DESCRIPTION
### Motivation
- Remove remaining hardcoded English literals from the translation/notification UI so all visible text can be localized per-locale via `mkdocs.yml`.
- Ensure dismiss button labels and GitHub-issue prefill strings switch with the site locale alongside existing `add_translations.*` values.

### Description
- Replaced hardcoded `aria-label` for dismiss buttons in `book_src/overrides/main.html` with `{{ config.extra.add_translations.dismiss_notification_aria | default(...) }}`.
- Replaced hardcoded GitHub issue prefill pieces (issue title prefix and body labels) in `book_src/overrides/main.html` with `config.extra.add_translations.* | default(...)` values.
- Added new keys `dismiss_notification_aria`, `issue_title_prefix`, `issue_body_page_label`, `issue_body_file_label`, and `issue_body_description_label` to `extra.add_translations` for all locales (`ru`, `en`, `uk`, `zh`) in `mkdocs.yml`.

### Testing
- Ran a search over the template with `rg` to confirm original literals are no longer present and the template references `config.extra.add_translations` entries; this succeeded.
- Ran a YAML inspection script to verify the new `add_translations` keys exist for `ru`, `en`, `uk`, and `zh`, producing `ru OK`, `en OK`, `uk OK`, `zh OK`.
- Verified the updated template links now build their GitHub prefill using the localized config values by checking the rendered URL construction in the template; automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa8d49914832aa6f6351762fe3136)